### PR TITLE
add -P:sxr:output-class:<class> option

### DIFF
--- a/src/main/scala/Browse.scala
+++ b/src/main/scala/Browse.scala
@@ -33,6 +33,8 @@ abstract class Browse extends Plugin
 	def classDirectory: File
 	/** The output formats to write */
 	def outputFormats: List[OutputFormat]
+	/** The output class that handle write logic */
+	def outputClass: String
 	/** The URLs of external sxr locations */
 	def externalLinkURLs: List[URL]
 	/** Relativizes the path to the given Scala source file against the base directories. */
@@ -57,7 +59,10 @@ abstract class Browse extends Plugin
 			links.clear(sourceFiles.map(getRelativeSourcePath(_)).toList)
 
 			val context = new OutputWriterContext(sourceFiles, outputDirectory, settings.encoding.value, externalLinkURLs)
-			val writers = outputFormats.map(getWriter(_, context))
+			val writers = if (outputClass != "")
+				Seq(getWriter(outputClass, context))
+			else
+				outputFormats.map(getWriter(_, context))
 			writers.foreach(_.writeStart())
 
 			for(unit <- currentRun.units ; sourceFile <- getSourceFile(unit))

--- a/src/main/scala/BrowsePlugin.scala
+++ b/src/main/scala/BrowsePlugin.scala
@@ -19,7 +19,7 @@ object BrowsePlugin
 	/** This is the name of the option that specifies the desired output formats.*/
 	val OutputFormatsOptionName = "output-formats:"
 	/** This is the name of the option that specifies the desired output class.*/
-	val OutputSingletonOptionName = "output-class:"
+	val OutputClassOptionName = "output-class:"
 	/** The separator in the list of output formats.*/
 	val OutputFormatSeparator = '+'
 	/** This is the name of the options that specifies a file containing one URL per line for each external sxr location to link to. */
@@ -56,7 +56,7 @@ class BrowsePlugin(val global: Global) extends Browse
 			else if(option.startsWith(OutputFormatsOptionName))
 				outputFormats = parseOutputFormats(option.substring(OutputFormatsOptionName.length))
 			else if(option.startsWith(OutputClassOptionName))
-				outputSingleton = option.substring(OutputClassOptionName.length)
+				outputClass = option.substring(OutputClassOptionName.length)
 			else if(option.startsWith(ExternalLinksOptionName))
 				externalLinkURLs = parseExternalLinks(option.substring(ExternalLinksOptionName.length))
 			else
@@ -90,10 +90,10 @@ class BrowsePlugin(val global: Global) extends Browse
 		val base = prefix + BaseDirectoryOptionName + "<paths>            Set the base source directories."
 		val formats = prefix + OutputFormatsOptionName + "<formats>          '" + OutputFormatSeparator +
 			"'-separated list of output formats to write (available: " + OutputFormat.all.mkString(",") + " - defaults to: " + Html + ")."
-		val singleton = prefix + OutputClassOptionName + "<class>            Set the output class."
+		val clazz = prefix + OutputClassOptionName + "<class>            Set the output class."
 		val link = prefix + ExternalLinksOptionName + "<path>            Set the file containing sxr link.index URLs for external linking."
 
-		Some( Seq(base, formats, class, link).mkString("", "\n", "\n") )
+		Some( Seq(base, formats, clazz, link).mkString("", "\n", "\n") )
 	}
 
 	private object Component extends PluginComponent

--- a/src/main/scala/BrowsePlugin.scala
+++ b/src/main/scala/BrowsePlugin.scala
@@ -18,6 +18,8 @@ object BrowsePlugin
 	val BaseDirectoryOptionName = "base-directory:"
 	/** This is the name of the option that specifies the desired output formats.*/
 	val OutputFormatsOptionName = "output-formats:"
+	/** This is the name of the option that specifies the desired output class.*/
+	val OutputSingletonOptionName = "output-class:"
 	/** The separator in the list of output formats.*/
 	val OutputFormatSeparator = '+'
 	/** This is the name of the options that specifies a file containing one URL per line for each external sxr location to link to. */
@@ -42,6 +44,9 @@ class BrowsePlugin(val global: Global) extends Browse
 	/** The output formats to write */
 	var outputFormats: List[OutputFormat] = List(Html)
 
+	/** The output class to write */
+	var outputClass: String = ""
+
 	override def processOptions(options: List[String], error: String => Unit)
 	{
 		for(option <- options)
@@ -50,6 +55,8 @@ class BrowsePlugin(val global: Global) extends Browse
 				baseDirectories = parseBaseDirectories(option.substring(BaseDirectoryOptionName.length))
 			else if(option.startsWith(OutputFormatsOptionName))
 				outputFormats = parseOutputFormats(option.substring(OutputFormatsOptionName.length))
+			else if(option.startsWith(OutputClassOptionName))
+				outputSingleton = option.substring(OutputClassOptionName.length)
 			else if(option.startsWith(ExternalLinksOptionName))
 				externalLinkURLs = parseExternalLinks(option.substring(ExternalLinksOptionName.length))
 			else
@@ -83,9 +90,10 @@ class BrowsePlugin(val global: Global) extends Browse
 		val base = prefix + BaseDirectoryOptionName + "<paths>            Set the base source directories."
 		val formats = prefix + OutputFormatsOptionName + "<formats>          '" + OutputFormatSeparator +
 			"'-separated list of output formats to write (available: " + OutputFormat.all.mkString(",") + " - defaults to: " + Html + ")."
+		val singleton = prefix + OutputClassOptionName + "<class>            Set the output class."
 		val link = prefix + ExternalLinksOptionName + "<path>            Set the file containing sxr link.index URLs for external linking."
 
-		Some( Seq(base, formats, link).mkString("", "\n", "\n") )
+		Some( Seq(base, formats, class, link).mkString("", "\n", "\n") )
 	}
 
 	private object Component extends PluginComponent

--- a/src/main/scala/OutputFormat.scala
+++ b/src/main/scala/OutputFormat.scala
@@ -24,4 +24,12 @@ object OutputFormat extends Enumeration {
 	/** Returns the writer corresponding to a value, configured with a context */
 	def getWriter(value: OutputFormat, context: OutputWriterContext): OutputWriter =
 		factory(value)(context)
+
+	/** Returns the writer corresponding to a value, configured with a context */
+	def getWriter(value: String, context: OutputWriterContext): OutputWriter = {
+		val loader = this.getClass.getClassLoader
+		val aClass = loader.loadClass(value)
+		val constructor = aClass.getConstructor(classOf[OutputWriterContext])
+		constructor.newInstance(context).asInstanceOf[OutputWriter]
+	}
 }

--- a/src/main/scala/Token.scala
+++ b/src/main/scala/Token.scala
@@ -10,7 +10,7 @@ package sxr
 * Specific writers need to construct the actual path from these informations (e.g in
 * HtmlWriter, add '.html' to get the relative path of the target HTML file, and append the
 * ID separated by a '#'. */
-private class Link(val path: String, val target: Int, val stableID: Option[String]) extends NotNull
+class Link(val path: String, val target: Int, val stableID: Option[String]) extends NotNull
 {
 	// This can still be useful for debugging, but must not be used directly by a writer.
 	override def toString = path + "#" + target
@@ -20,7 +20,7 @@ private class Link(val path: String, val target: Int, val stableID: Option[Strin
 * 'start' is the offset of the token in the original source file.
 * 'length' is the length of the token in the original source file
 * 'code' is the class of the token (see Tokens in the compiler)*/
-private case class Token(start: Int, length: Int, code: Int) extends NotNull with Ordered[Token] with Comparable[Token]
+case class Token(start: Int, length: Int, code: Int) extends NotNull with Ordered[Token] with Comparable[Token]
 {
 	require(start >= 0)
 	require(length > 0)
@@ -90,4 +90,4 @@ private case class Token(start: Int, length: Int, code: Int) extends NotNull wit
 	}
 }
 /** Holds type information.  This class will probably change to accomodate tokeninzing types. */
-private case class TypeAttribute(name: String, definition: Option[Link]) extends NotNull
+case class TypeAttribute(name: String, definition: Option[Link]) extends NotNull


### PR DESCRIPTION
Dear Mark,
   Thank you very much for 'browse'. I slightly modify your code by adding new option. I try to preserve all punctuation, tabs, \r\n. I hope that addition look like original code. This new option allow add external class writer for sxr.

For example
somewhere at build.sbt or like one:
    scalacOptions += "-Xplugin:other.package.jar"
    scalacOptions <+= (scalaSource in Compile) map { (source) => { "-P:sxr:output-class:other.package.CustomWriter" }

Our custom writer

package other.package

import java.io.File
import sxr.OutputWriter
import sxr.Token
import sxr.OutputWriterContext

class CustomWriter(context: OutputWriterContext) extends OutputWriter {
  /*\* Generates initial content. */
  def writeStart() {
  }

  /*\* Generates content for a given source file. */
  def writeUnit(source: File, relativeSourcePath: String, tokenList: List[Token]) {
    println("--- " + source.toString)
    ...
    withReader(source, context.encoding) { input =>
      withWriter(destination) { output =>
    tokenList.foreach( ... custom code ...))
      }
    }
  }

  /*\* Generates final content. */
  def writeEnd() {
  }
}

It's work surprisingly well. I hope that you accept this addition. If i need it modify, please tell me about.

King regards,
Alexey
