### PR TITLE
Fix definition() in linked.js (previous commit was wrong)

### DIFF
--- a/src/main/resources/linked.js
+++ b/src/main/resources/linked.js
@@ -99,7 +99,8 @@ $(window).load(function() {
 
 jQuery.fn.extend({
 	definition: function() {
-		return $(this.attr("href").replace(/(\.|:|;)/g, '\\.'));
+		var target = document.getElementById(this.attr("href").replace(/^#/, ''));
+		return target ? $(target) : $(this);
 	},
 	references: function() {
 		return $("a[href$='#" + this.attr('id') +"']")


### PR DESCRIPTION
Hi Mark,

Could you please merge this one. Sorry, my previous patch was incorrect. I have tested this one and it works. It fixes two issue (1) the escaping of css selector is not required anymore since it uses getElementById (2) if the target is not found, it returns the current element so the page will not jump to the top
