### PR TITLE
Fix for #16 - case classes defined in methods cause error

### DIFF
--- a/src/main/scala/Browse.scala
+++ b/src/main/scala/Browse.scala
@@ -448,9 +448,13 @@ abstract class Browse extends Plugin
 		if(sym.isModuleClass) {
 			val mod = sym.companionModule
 			if(mod == NoSymbol) sym else mod
-		} else if(sym.isCaseApplyOrUnapply)
-			sym.owner.companionClass
-		else if(sym.isPrimaryConstructor)
+		} else if(sym.isCaseApplyOrUnapply) {
+			val cClass = sym.owner.companionClass
+      if(cClass != NoSymbol)
+        cClass
+      else
+        sym.owner
+    } else if(sym.isPrimaryConstructor)
 			sym.owner
 		else if(sym.isStable && sym.isMethod) {
 			val get = sym.getter(sym.enclClass)

--- a/test/NestedDefs.scala
+++ b/test/NestedDefs.scala
@@ -12,4 +12,10 @@ object NestedDefs
 			c + k5 + (new K6.K7).hashCode
 		}
 	}
+
+  // test case class usage within a method
+  def foo(x : Int) = {
+    case class Result(i : Int)
+    Result(x)
+  }
 }

--- a/test/expected/NestedDefs.scala.html
+++ b/test/expected/NestedDefs.scala.html
@@ -24,7 +24,13 @@
 			<a href="#NestedDefs.K.k4.c" title="=&gt; String">c</a> <span title="(x$1: Any)String">+</span> <a href="#NestedDefs.K.k4.k5" title="=&gt; String">k5</a> <span title="(x$1: Any)String">+</span> <span class="delimiter">(</span><span title="K6.K7" class="keyword">new</span> <a href="#NestedDefs.K.k4.K6" title="K6.type">K6</a>.<a href="#NestedDefs.K.k4;K6;K7" title="K6.K7">K7</a><span class="delimiter">)</span>.<span title="()Int">hashCode</span>
 		<span class="delimiter">}</span>
 	<span class="delimiter">}</span>
-<span title="AnyRef" class="delimiter">}</span>
+
+  <span class="comment">// test case class usage within a method</span>
+  <span class="keyword">def</span> <a title="(x: Int)Result forSome { type Result &lt;: Product with Serializable{val i: Int; def copy(i: Int): Result; def copy$default$1: Int} }" id="NestedDefs.foo">foo</a><span class="delimiter">(</span><a title="Int" id="NestedDefs.foo.x">x</a> : <span title="Int">Int</span><span class="delimiter">)</span> = <span class="delimiter">{</span>
+    <span class="keyword">case class</span> <a title="class Result extends AnyRef with Product with Serializable" id="NestedDefs.foo;Result.readResolve">Result</a><a href="#NestedDefs.foo;Result.readResolve" title="Product" class="delimiter">(</a><a title="Int" id="NestedDefs.foo;Result.i">i</a> : <span title="Int">Int</span><span class="delimiter">)</span>
+    <a href="#NestedDefs.foo;Result.readResolve" title="(i: Int)Result">Result</a><span class="delimiter">(</span><a href="#NestedDefs.foo.x" title="Int">x</a><span class="delimiter">)</span>
+  <span class="delimiter">}</span>
+<span class="delimiter">}</span>
         </pre>
     </body>
 </html>


### PR DESCRIPTION
Updated as per discussion of issue 16 - Fixes bug with case classes defined in method body.  Fixes code generation for play framework.
